### PR TITLE
feat: 기업명 필드 추가 및 Google Sheet 연동 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### Key files ###
 firstinvest-google-spread-sheet-key.json
+/local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.projectlombok:lombok:1.18.34'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
@@ -40,7 +41,7 @@ dependencies {
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.37.1'
 
     // Telegram Bots Spring Boot Starter
-    implementation 'org.telegram:telegrambots-spring-boot-starter:7.4.0'
+    implementation 'org.telegram:telegrambots-springboot-webhook-starter:7.4.0'
 
 }
 

--- a/src/main/java/com/realyoungk/sdi/config/GoogleSheetsProperties.java
+++ b/src/main/java/com/realyoungk/sdi/config/GoogleSheetsProperties.java
@@ -2,6 +2,7 @@ package com.realyoungk.sdi.config;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -11,5 +12,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @param dataRange     조회할 데이터의 범위 (예: "Sheet1!C3:G")
  */
 @ConfigurationProperties(prefix = "google.sheets")
-public record GoogleSheetsProperties(String spreadsheetId, String dataRange) {
+public record GoogleSheetsProperties(String spreadsheetId, String titleRange, String dataRange) {
 }

--- a/src/main/java/com/realyoungk/sdi/controller/VisitController.java
+++ b/src/main/java/com/realyoungk/sdi/controller/VisitController.java
@@ -2,6 +2,7 @@ package com.realyoungk.sdi.controller;
 
 import com.realyoungk.sdi.model.VisitModel;
 import com.realyoungk.sdi.service.VisitService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,14 +12,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/visits")
 public class VisitController {
-
     private final VisitService visitService;
 
     public VisitController(VisitService visitService) {
         this.visitService = visitService;
     }
 
-    @GetMapping
+    @GetMapping("")
     public List<VisitModel> getVisits(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Date startedAt) {
         return visitService.fetchUpcoming(startedAt);
     }

--- a/src/main/java/com/realyoungk/sdi/model/VisitModel.java
+++ b/src/main/java/com/realyoungk/sdi/model/VisitModel.java
@@ -12,6 +12,8 @@ import java.util.Date;
 // 탐방
 public class VisitModel {
     private String id;
+    // 회사명
+    private String companyName;
     // 시작시각
     private Date startedAt;
     // 끝나는시각
@@ -26,8 +28,9 @@ public class VisitModel {
     private String remark;
 
     @Builder
-    public VisitModel(String id, Date startedAt, Date finishedAt, String participantCount, String teamName, String organizer, String remark) {
+    public VisitModel(String id, String companyName, Date startedAt, Date finishedAt, String participantCount, String teamName, String organizer, String remark) {
         this.id = id;
+        this.companyName = companyName;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;
         this.participantCount = participantCount;
@@ -40,6 +43,7 @@ public class VisitModel {
         SimpleDateFormat dateFormat = new SimpleDateFormat("M월 d일(E)");
         StringBuilder sb = new StringBuilder();
         sb.append(String.format("‼️ *D-%d* ‼️\n", daysUntil));
+        sb.append(String.format("*회사명*: %s\n", this.companyName));
         sb.append(String.format("*일시*: %s\n", dateFormat.format(this.startedAt)));
         sb.append(String.format("*기수*: %s\n", this.teamName));
         sb.append(String.format("*주선자*: %s\n", this.organizer));
@@ -53,8 +57,9 @@ public class VisitModel {
 
     public String toSimpleString() {
         SimpleDateFormat dateFormat = new SimpleDateFormat("M월 d일(E)");
-        return String.format("🗓️ %s - %s (%s 주선)",
+        return String.format("🗓️ %s - %s (%s %s 주선)",
                 dateFormat.format(this.startedAt),
+                this.participantCount,
                 this.teamName,
                 this.organizer);
     }

--- a/src/main/java/com/realyoungk/sdi/repository/GoogleSheetRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/GoogleSheetRepository.java
@@ -29,9 +29,6 @@ import java.util.List;
 public class GoogleSheetRepository {
     private static final String APPLICATION_NAME = "sdi-server";
     private static final String CREDENTIALS_FILE_PATH = "firstinvest-google-spread-sheet-key.json";
-    public static final String SDI_VISIT_SPREADSHEET_ID = "1jXaJ7gsIMIJi1gfTx96iPi85O9WEJW-np4pE-ItL2l4";
-    static final String TITLE_RANGE = "Sheet1!C3:G3";
-    public static final String DATA_RANGE = "Sheet1!C3:G";
 
     public List<List<Object>> readSheet(String spreadsheetId, String range) throws IOException, GeneralSecurityException {
         Sheets sheets = getSheets();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,7 +18,17 @@ telegram:
     username: "1기봇"
     token: ${FIRST_BOT_TOKEN}
 
+telegrambots:
+  enabled: true
+  bots:
+    - username: <Bot Username> # BotFather에서 받은 봇 사용자명
+      token: <Bot Token>
+      path: /telegram # 봇에 접근할 엔드포인트(기본값 권장: `/telegram`)
+      webhook:
+        url: https://<도메인 또는 IP>/telegram
+
 google:
   sheets:
     spreadsheet-id: "1jXaJ7gsIMIJi1gfTx96iPi85O9WEJW-np4pE-ItL2l4"
-    data-range: "Sheet1!C3:G"
+    title-range: "Sheet1!B3:G3"
+    data-range: "Sheet1!B4:G"

--- a/src/test/java/com/realyoungk/sdi/repository/GoogleSheetRepositoryTest.java
+++ b/src/test/java/com/realyoungk/sdi/repository/GoogleSheetRepositoryTest.java
@@ -1,31 +1,38 @@
 package com.realyoungk.sdi.repository;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.realyoungk.sdi.config.GoogleSheetsProperties;
 
 @SpringBootTest
 class GoogleSheetRepositoryTest {
 
     @Autowired
     private GoogleSheetRepository googleSheetRepository;
-
+    @Autowired
+    private GoogleSheetsProperties googleSheetsProperties;
 
     @Test
     void readSheetTitle() throws Exception {
         List<List<Object>> result = googleSheetRepository
-                .readSheet(GoogleSheetRepository.SDI_VISIT_SPREADSHEET_ID, GoogleSheetRepository.TITLE_RANGE);
+                .readSheet(googleSheetsProperties.spreadsheetId(), googleSheetsProperties.titleRange());
 
         assertNotNull(result);
-        assertEquals("기업명", result.getFirst().getFirst());
-        assertEquals("기수", result.getFirst().get(1));
-        assertEquals("주선자", result.getFirst().get(2));
-        assertEquals("참여 인원", result.getFirst().get(3));
-        assertEquals("비고", result.getFirst().get(4));
+        assertEquals("날짜", result.getFirst().getFirst());
+        assertEquals("기업명", result.getFirst().get(1));
+        assertEquals("기수", result.getFirst().get(2));
+        assertEquals("주선자", result.getFirst().get(3));
+        assertEquals("참여 인원", result.getFirst().get(4));
+        assertEquals("비고", result.getFirst().get(5));
     }
 }
 


### PR DESCRIPTION
탐방 정보(`VisitModel`)에 '기업명'(`companyName`) 필드를 추가하고, 관련 Google Sheet 연동 로직을 개선했습니다.

주요 변경 사항:

- **VisitModel**: `companyName` 필드 추가 및 관련 생성자, `toDetailString` 메서드 업데이트.
- **VisitController**: `/api/v1/visits` 엔드포인트 경로 수정 (`/api/v1/visits` -> `/api/v1/visits/`).
- **Google Sheet 연동**:
    - `application.yaml`: Google Sheet의 `title-range` 및 `data-range` 설정을 B열부터 시작하도록 변경 (기존 C열).
    - `GoogleSheetRepository`: 하드코딩된 스프레드시트 ID 및 범위 상수 제거 (설정 파일 값 사용).
    - `GoogleSheetsProperties`: `titleRange` 설정 추가.
    - `VisitService`:
        - Google Sheet 데이터 파싱 로직에서 기업명(`companyName`)을 C열에서 읽도록 수정.
        - 날짜 형식 파싱 로직을 `yyyy.MM.dd`에서 `yy.MM.dd`로 변경. - `IndexOutOfBoundsException` 방지를 위해 `safeToString` 헬퍼 메서드 도입.
- **build.gradle**: `telegrambots-springboot-webhook-starter` 의존성 추가.
- **GoogleSheetRepositoryTest**: 테스트 코드에서 새로운 열(날짜) 및 기업명 필드 검증 로직 추가.