### PR TITLE
feat: 탐방 일정 조회 API 응답 포맷 및 로직 변경

### DIFF
--- a/src/main/java/com/realyoungk/sdi/controller/VisitController.java
+++ b/src/main/java/com/realyoungk/sdi/controller/VisitController.java
@@ -6,11 +6,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/visits")
+@RequestMapping(value = "/api/v1/visits", method = {RequestMethod.GET, RequestMethod.POST})
 public class VisitController {
     private final VisitService visitService;
 
@@ -18,9 +21,27 @@ public class VisitController {
         this.visitService = visitService;
     }
 
-    @GetMapping("")
-    public List<VisitModel> getVisits(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Date startedAt) {
-        return visitService.fetchUpcoming(startedAt);
+    @GetMapping(value = "")
+    public String getVisits() {
+        final LocalDateTime localDateTime = LocalDateTime.now();
+        final Date startedAt = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        final List<VisitModel> visitModels = visitService.fetchUpcoming(startedAt);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("[다가오는 탐방 일정]\n\n");
+
+        for (VisitModel visitModel : visitModels) {
+            long diff = (visitModel.getStartedAt().getTime() - startedAt.getTime()) / (1000 * 60 * 60 * 24);
+
+            if (diff >= 0 && diff <= 2) {
+                sb.append(visitModel.toDetailedString(diff));
+                sb.append("\n");
+            } else {
+                sb.append(visitModel.toSimpleString(diff));
+            }
+        }
+
+        return sb.toString();
     }
 
     @PostMapping("/new")

--- a/src/main/java/com/realyoungk/sdi/model/VisitModel.java
+++ b/src/main/java/com/realyoungk/sdi/model/VisitModel.java
@@ -51,15 +51,13 @@ public class VisitModel {
         if (this.remark != null && !this.remark.isBlank()) {
             sb.append(String.format("*비고*: %s\n", this.remark));
         }
-        sb.append("--------------------");
         return sb.toString();
     }
 
-    public String toSimpleString() {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("M월 d일(E)");
-        return String.format("🗓️ %s - %s (%s %s 주선)",
-                dateFormat.format(this.startedAt),
-                this.participantCount,
+    public String toSimpleString(long daysUtil) {
+        return String.format("🗓️ D-%s / %s / %s %s\n",
+                daysUtil,
+                this.companyName,
                 this.teamName,
                 this.organizer);
     }

--- a/src/main/java/com/realyoungk/sdi/service/VisitService.java
+++ b/src/main/java/com/realyoungk/sdi/service/VisitService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.text.ParseException;
+import java.util.Comparator;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -42,14 +43,15 @@ public class VisitService {
             return sheetData.stream()
                     .map(this::fromSheetRow)
                     .filter(Objects::nonNull)
-                    .filter(model -> model.getStartedAt().after(startedAt))
+                    .filter(model -> model.getStartedAt() != null && model.getStartedAt().after(startedAt))
+                    .sorted(Comparator.comparing(VisitModel::getStartedAt))
                     .collect(Collectors.toList());
 
         } catch (IOException | GeneralSecurityException e) {
             log.error("Google Sheet에서 데이터를 가져오는 중 오류가 발생했습니다.", e);
             throw new VisitFetchException("방문 일정을 가져올 수 없습니다. 잠시 후 다시 시도해주세요.", e);
         }
-    }
+    }    // 다가오는 탐방 일정 조회 (정렬 추가)
 
     // 탐방 일정 저장
     public VisitModel save(VisitModel visitModel) {


### PR DESCRIPTION
- `/api/v1/visits` 엔드포인트 응답 형식을 `List<VisitModel>`에서 가공된 `String`으로 변경했습니다.
- 탐방 일정 조회 시, `startedAt` 파라미터 대신 현재 시간을 기준으로 조회하도록 변경했습니다.
- 조회된 탐방 일정을 `startedAt` 기준으로 오름차순 정렬하도록 수정했습니다.
- `VisitModel`의 `toSimpleString` 메서드 시그니처를 변경하고, 남은 일수(D-day)를 포함하도록 수정했습니다.
- `VisitModel`의 `toDetailedString` 메서드를 추가하여 상세 정보를 포함한 문자열을 생성합니다. (기존 `toString` 로직과 유사)
  - `toDetailedString` 호출 시, 남은 일수가 2일 이하인 경우에만 사용됩니다.
- `VisitController`의 `@RequestMapping`에 `method` 속성을 명시적으로 추가했습니다.
- `VisitService`의 `fetchUpcoming` 메서드에서 `startedAt`이 null인 경우를 방지하기 위해 필터링 로직을 강화했습니다.