### PR TITLE
feat: 탐방 일정 조회 API 응답 포맷 및 로직 변경

### DIFF
--- a/src/main/java/com/realyoungk/sdi/config/TelegramProperties.java
+++ b/src/main/java/com/realyoungk/sdi/config/TelegramProperties.java
@@ -2,6 +2,6 @@ package com.realyoungk.sdi.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "telegram.bot")
-public record TelegramProperties(String username, String token) {
+@ConfigurationProperties(prefix = "telegram")
+public record TelegramProperties(String botId, String botToken, String baseUrl, String testChatId) {
 }

--- a/src/main/java/com/realyoungk/sdi/controller/VisitController.java
+++ b/src/main/java/com/realyoungk/sdi/controller/VisitController.java
@@ -23,25 +23,7 @@ public class VisitController {
 
     @GetMapping(value = "")
     public String getVisits() {
-        final LocalDateTime localDateTime = LocalDateTime.now();
-        final Date startedAt = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
-        final List<VisitModel> visitModels = visitService.fetchUpcoming(startedAt);
-
-        StringBuilder sb = new StringBuilder();
-        sb.append("[다가오는 탐방 일정]\n\n");
-
-        for (VisitModel visitModel : visitModels) {
-            long diff = (visitModel.getStartedAt().getTime() - startedAt.getTime()) / (1000 * 60 * 60 * 24);
-
-            if (diff >= 0 && diff <= 2) {
-                sb.append(visitModel.toDetailedString(diff));
-                sb.append("\n");
-            } else {
-                sb.append(visitModel.toSimpleString(diff));
-            }
-        }
-
-        return sb.toString();
+        return visitService.getUpcomingMessage();
     }
 
     @PostMapping("/new")

--- a/src/main/java/com/realyoungk/sdi/repository/TelegramRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/TelegramRepository.java
@@ -1,0 +1,30 @@
+package com.realyoungk.sdi.repository;
+
+import com.realyoungk.sdi.config.TelegramProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class TelegramRepository {
+    final private TelegramProperties telegramProperties;
+
+    public void sendMessage(String chatId, String message) {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = telegramProperties.baseUrl() + telegramProperties.botToken() + "/sendMessage?chat_id=" + chatId + "&text=" + message;
+
+        System.out.print(url);
+
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            log.info("Message sent successfully: {}", message);
+        } else {
+            log.error("Failed to send message: {} - {}", response.getStatusCode(), response.getBody());
+        }
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/service/VisitService.java
+++ b/src/main/java/com/realyoungk/sdi/service/VisitService.java
@@ -1,10 +1,12 @@
 package com.realyoungk.sdi.service;
 
 import com.realyoungk.sdi.config.GoogleSheetsProperties;
+import com.realyoungk.sdi.config.TelegramProperties;
 import com.realyoungk.sdi.entity.VisitEntity;
 import com.realyoungk.sdi.exception.VisitFetchException;
 import com.realyoungk.sdi.model.VisitModel;
 import com.realyoungk.sdi.repository.GoogleSheetRepository;
+import com.realyoungk.sdi.repository.TelegramRepository;
 import com.realyoungk.sdi.repository.VisitRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,12 +15,13 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -27,37 +30,59 @@ public class VisitService {
     private final VisitRepository visitRepository;
     private final GoogleSheetRepository googleSheetRepository;
     private final GoogleSheetsProperties googleSheetsProperties;
+    private final TelegramProperties telegramProperties;
+    private final TelegramRepository telegramRepository;
 
-    // 다가오는 탐방 일정 조회
-    public List<VisitModel> fetchUpcoming(Date startedAt) {
-        try {
-            final List<List<Object>> sheetData = googleSheetRepository.readSheet(
-                    googleSheetsProperties.spreadsheetId(),
-                    googleSheetsProperties.dataRange()
-            );
+    public String getUpcomingMessage() {
+        final LocalDateTime localDateTime = LocalDateTime.now();
+        final Date startedAt = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        final List<VisitModel> visitModels = fetchUpcoming(startedAt);
 
-            if (sheetData == null) {
-                return List.of();
+        StringBuilder sb = new StringBuilder();
+        sb.append("[다가오는 탐방 일정]\n\n");
+        for (VisitModel visitModel : visitModels) {
+            long diff = (visitModel.getStartedAt().getTime() - startedAt.getTime()) / (1000 * 60 * 60 * 24);
+            boolean isSoon = diff >= 0 && diff <= 2;
+            if (isSoon) {
+                sb.append(visitModel.toDetailedString(diff));
+                sb.append("\n");
+            } else {
+                sb.append(visitModel.toSimpleString(diff));
             }
-
-            return sheetData.stream()
-                    .map(this::fromSheetRow)
-                    .filter(Objects::nonNull)
-                    .filter(model -> model.getStartedAt() != null && model.getStartedAt().after(startedAt))
-                    .sorted(Comparator.comparing(VisitModel::getStartedAt))
-                    .collect(Collectors.toList());
-
-        } catch (IOException | GeneralSecurityException e) {
-            log.error("Google Sheet에서 데이터를 가져오는 중 오류가 발생했습니다.", e);
-            throw new VisitFetchException("방문 일정을 가져올 수 없습니다. 잠시 후 다시 시도해주세요.", e);
         }
-    }    // 다가오는 탐방 일정 조회 (정렬 추가)
+        final String message = sb.toString();
+
+        telegramRepository.sendMessage(telegramProperties.testChatId(), message);
+        return message;
+    }
 
     // 탐방 일정 저장
     public VisitModel save(VisitModel visitModel) {
         final VisitEntity savedVisitEntity = visitRepository.save(VisitEntity.fromModel(visitModel));
 
         return fromEntity(savedVisitEntity);
+    }
+
+    // 다가오는 탐방 일정 조회
+    private List<VisitModel> fetchUpcoming(Date startedAt) {
+        try {
+            final List<List<Object>> sheetData = googleSheetRepository.readSheet(
+                    googleSheetsProperties.spreadsheetId(),
+                    googleSheetsProperties.dataRange()
+            );
+
+            if (sheetData == null) return List.of();
+
+            return sheetData.stream()
+                    .map(this::fromSheetRow)
+                    .filter(Objects::nonNull)
+                    .filter(model -> model.getStartedAt() != null && model.getStartedAt().after(startedAt))
+                    .sorted(Comparator.comparing(VisitModel::getStartedAt))
+                    .toList();
+        } catch (IOException | GeneralSecurityException e) {
+            log.error("Google Sheet에서 데이터를 가져오는 중 오류가 발생했습니다.", e);
+            throw new VisitFetchException("방문 일정을 가져올 수 없습니다. 잠시 후 다시 시도해주세요.", e);
+        }
     }
 
     private VisitModel fromEntity(VisitEntity visitEntity) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,18 +14,10 @@ spring:
     password: ${DB_PASSWORD}
 
 telegram:
-  bot:
-    username: "1기봇"
-    token: ${FIRST_BOT_TOKEN}
-
-telegrambots:
-  enabled: true
-  bots:
-    - username: <Bot Username> # BotFather에서 받은 봇 사용자명
-      token: <Bot Token>
-      path: /telegram # 봇에 접근할 엔드포인트(기본값 권장: `/telegram`)
-      webhook:
-        url: https://<도메인 또는 IP>/telegram
+  bot-id: "1기봇"
+  bot-token: ${FIRST_BOT_TOKEN}
+  base-url: "https://api.telegram.org/bot"
+  test-chat-id: "1667145350" # 1기봇 채팅방
 
 google:
   sheets:

--- a/src/test/java/com/realyoungk/sdi/repository/GoogleSheetRepositoryTest.java
+++ b/src/test/java/com/realyoungk/sdi/repository/GoogleSheetRepositoryTest.java
@@ -1,8 +1,6 @@
 package com.realyoungk.sdi.repository;
 
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 


### PR DESCRIPTION
- `/api/v1/visits` 엔드포인트 응답 형식을 `List<VisitModel>`에서 가공된 `String`으로 변경했습니다.
- 탐방 일정 조회 시, `startedAt` 파라미터 대신 현재 시간을 기준으로 조회하도록 변경했습니다.
- 조회된 탐방 일정을 `startedAt` 기준으로 오름차순 정렬하도록 수정했습니다.
- `VisitModel`의 `toSimpleString` 메서드 시그니처를 변경하고, 남은 일수(D-day)를 포함하도록 수정했습니다.
- `VisitModel`의 `toDetailedString` 메서드를 추가하여 상세 정보를 포함한 문자열을 생성합니다. (기존 `toString` 로직과 유사)
  - `toDetailedString` 호출 시, 남은 일수가 2일 이하인 경우에만 사용됩니다.
- `VisitController`의 `@RequestMapping`에 `method` 속성을 명시적으로 추가했습니다.
- `VisitService`의 `fetchUpcoming` 메서드에서 `startedAt`이 null인 경우를 방지하기 위해 필터링 로직을 강화했습니다.