### PR TITLE
feat: Telegram 메시지 발송 기능 구현 및 `RestTemplate` 빈 등록

### DIFF
--- a/src/main/java/com/realyoungk/sdi/config/AppConfig.java
+++ b/src/main/java/com/realyoungk/sdi/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.realyoungk.sdi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/controller/VisitController.java
+++ b/src/main/java/com/realyoungk/sdi/controller/VisitController.java
@@ -23,7 +23,7 @@ public class VisitController {
 
     @GetMapping(value = "")
     public List<VisitModel> getVisits() {
-        return visitService.getUpcomingMessage();
+        return visitService.getUpcomingVisits();
     }
 
     @PostMapping("/new")

--- a/src/main/java/com/realyoungk/sdi/repository/TelegramRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/TelegramRepository.java
@@ -3,26 +3,34 @@ package com.realyoungk.sdi.repository;
 import com.realyoungk.sdi.config.TelegramProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
 
 @Slf4j
 @Repository
 @RequiredArgsConstructor
 public class TelegramRepository {
     final private TelegramProperties telegramProperties;
+    final private RestTemplate restTemplate;
 
     public void sendMessage(String chatId, String message) {
-        RestTemplate restTemplate = new RestTemplate();
-        String url = telegramProperties.baseUrl() + telegramProperties.botToken() + "/sendMessage?chat_id=" + chatId + "&text=" + message;
+        String url = telegramProperties.baseUrl() + telegramProperties.botToken() + "/sendMessage";
 
-        System.out.print(url);
+        URI uri = UriComponentsBuilder.fromUriString(url)
+                .queryParam("chat_id", chatId)
+                .queryParam("text", message)
+                .build(true)
+                .toUri();
 
-        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+        ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
 
         if (response.getStatusCode().is2xxSuccessful()) {
-            log.info("Message sent successfully: {}", message);
+            log.info("Message sent successfully to chat_id: {}", chatId);
         } else {
             log.error("Failed to send message: {} - {}", response.getStatusCode(), response.getBody());
         }


### PR DESCRIPTION
- `AppConfig`에 `RestTemplate` 빈을 등록하여 의존성 주입을 통해 사용하도록 변경했습니다.
- `TelegramRepository`에서 `RestTemplate`을 사용하여 Telegram 메시지를 발송하도록 구현했습니다.
- `VisitService`의 `getUpcomingMessage` 메서드 이름을 `createUpcomingVisitsMessage`로 변경하고, Telegram 메시지 발송 로직을 제거하여 메시지 생성 기능만 담당하도록 수정했습니다.
- `VisitService`의 `fetchUpcoming` 메서드에서 `startedAt` 파라미터를 제거하고 메서드 내부에서 현재 시간을 기준으로 조회하도록 변경했습니다.