### PR TITLE
refactor: `VisitEntity`를 `VisitDto`로 이름 변경

### DIFF
--- a/src/main/java/com/realyoungk/sdi/dto/VisitDto.java
+++ b/src/main/java/com/realyoungk/sdi/dto/VisitDto.java
@@ -1,4 +1,4 @@
-package com.realyoungk.sdi.entity;
+package com.realyoungk.sdi.dto;
 
 import com.realyoungk.sdi.model.VisitModel;
 import jakarta.persistence.Entity;
@@ -18,7 +18,7 @@ import java.util.UUID;
 @EqualsAndHashCode(of = "id")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class VisitEntity {
+public class VisitDto {
     @Id
     private String id;
     private Date createdAt;
@@ -38,7 +38,7 @@ public class VisitEntity {
     private String remark;
 
     @Builder
-    private VisitEntity(String id, Date createdAt, Date updatedAt, Date startedAt, Date finishedAt, String participantCount, String teamName, String organizer, String remark) {
+    private VisitDto(String id, Date createdAt, Date updatedAt, Date startedAt, Date finishedAt, String participantCount, String teamName, String organizer, String remark) {
         this.id = id;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -50,8 +50,8 @@ public class VisitEntity {
         this.remark = remark;
     }
 
-    public static VisitEntity fromModel(VisitModel model) {
-        return VisitEntity.builder()
+    public static VisitDto fromModel(VisitModel model) {
+        return VisitDto.builder()
                 .id(UUID.randomUUID().toString())
                 .createdAt(new Date())
                 .updatedAt(new Date())

--- a/src/main/java/com/realyoungk/sdi/repository/VisitJpaRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/VisitJpaRepository.java
@@ -1,7 +1,7 @@
 package com.realyoungk.sdi.repository;
 
-import com.realyoungk.sdi.entity.VisitEntity;
+import com.realyoungk.sdi.dto.VisitDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VisitJpaRepository extends JpaRepository<VisitEntity, String>, VisitRepository {
+public interface VisitJpaRepository extends JpaRepository<VisitDto, String>, VisitRepository {
 }

--- a/src/main/java/com/realyoungk/sdi/repository/VisitRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/VisitRepository.java
@@ -1,7 +1,7 @@
 package com.realyoungk.sdi.repository;
 
 
-import com.realyoungk.sdi.entity.VisitEntity;
+import com.realyoungk.sdi.dto.VisitDto;
 import org.springframework.stereotype.Repository;
 
 import java.util.Date;
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Repository
 public interface VisitRepository {
-    List<VisitEntity> findByStartedAtAfterOrderByStartedAtDesc(Date startedAt);
+    List<VisitDto> findByStartedAtAfterOrderByStartedAtDesc(Date startedAt);
 
-    VisitEntity save(VisitEntity visitEntity);
+    VisitDto save(VisitDto visitDto);
 }

--- a/src/main/java/com/realyoungk/sdi/service/VisitService.java
+++ b/src/main/java/com/realyoungk/sdi/service/VisitService.java
@@ -1,7 +1,7 @@
 package com.realyoungk.sdi.service;
 
 import com.realyoungk.sdi.config.GoogleSheetsProperties;
-import com.realyoungk.sdi.entity.VisitEntity;
+import com.realyoungk.sdi.dto.VisitDto;
 import com.realyoungk.sdi.exception.VisitFetchException;
 import com.realyoungk.sdi.model.VisitModel;
 import com.realyoungk.sdi.repository.GoogleSheetRepository;
@@ -57,9 +57,9 @@ public class VisitService {
     }
 
     public VisitModel save(VisitModel visitModel) {
-        final VisitEntity savedVisitEntity = visitRepository.save(VisitEntity.fromModel(visitModel));
+        final VisitDto savedVisitDto = visitRepository.save(VisitDto.fromModel(visitModel));
 
-        return fromEntity(savedVisitEntity);
+        return fromEntity(savedVisitDto);
     }
 
     public List<VisitModel> fetchUpcoming() {
@@ -88,15 +88,15 @@ public class VisitService {
         }
     }
 
-    private VisitModel fromEntity(VisitEntity visitEntity) {
+    private VisitModel fromEntity(VisitDto visitDto) {
         return VisitModel.builder()
-                .id(visitEntity.getId())
-                .startedAt(visitEntity.getStartedAt())
-                .finishedAt(visitEntity.getFinishedAt())
-                .participantCount(visitEntity.getParticipantCount())
-                .teamName(visitEntity.getTeamName())
-                .organizer(visitEntity.getOrganizer())
-                .remark(visitEntity.getRemark())
+                .id(visitDto.getId())
+                .startedAt(visitDto.getStartedAt())
+                .finishedAt(visitDto.getFinishedAt())
+                .participantCount(visitDto.getParticipantCount())
+                .teamName(visitDto.getTeamName())
+                .organizer(visitDto.getOrganizer())
+                .remark(visitDto.getRemark())
                 .build();
     }
 


### PR DESCRIPTION
`VisitEntity` 클래스의 이름을 `VisitDto`로 변경하여, 해당 클래스가 데이터 전송 객체(DTO)임을 더 명확히 나타냅니다. 이 변경 사항에는 다음이 포함됩니다:
	•	클래스 파일명을 `VisitEntity.java`에서 `VisitDto.java`로 변경
	•	`VisitService`, `VisitJpaRepository`, `VisitRepository` 등 프로젝트 전체에서 `VisitEntity` 사용 부분을 모두 `VisitDto`로 변경
	•	관련 패키지 import 구문도 모두 수정