### PR TITLE
feat: 텔레그램 봇 연동 기능 추가 및 알림 서비스 구현

### DIFF
--- a/src/main/java/com/realyoungk/sdi/controller/CallbackController.java
+++ b/src/main/java/com/realyoungk/sdi/controller/CallbackController.java
@@ -1,0 +1,39 @@
+package com.realyoungk.sdi.controller;
+
+import com.realyoungk.sdi.dto.TelegramUpdateDto;
+import com.realyoungk.sdi.service.NotificationService;
+import com.realyoungk.sdi.service.VisitService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/v1/callbacks", method = {RequestMethod.POST})
+public class CallbackController {
+    private final VisitService visitService;
+    private final NotificationService notificationService;
+
+    @PostMapping("/telegram")
+    public void postTelegram(@RequestBody TelegramUpdateDto update) {
+        if (update == null || update.message() == null || update.message().text() == null) {
+            log.warn("Received an empty or invalid update from Telegram.");
+            return;
+        }
+
+        String text = update.message().text();
+        String chatId = String.valueOf(update.message().chat().id());
+        log.info("Received message '{}' from chat_id '{}'", text, chatId);
+
+        if ("/visits".equalsIgnoreCase(text.trim())) {
+            final String visitsMessage = visitService.createMessage();
+            notificationService.send(chatId, visitsMessage);
+            log.info("Delegated /visits command for chat_id '{}' to VisitService", chatId);
+        }
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/controller/VisitController.java
+++ b/src/main/java/com/realyoungk/sdi/controller/VisitController.java
@@ -2,14 +2,8 @@ package com.realyoungk.sdi.controller;
 
 import com.realyoungk.sdi.model.VisitModel;
 import com.realyoungk.sdi.service.VisitService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
-import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
 import java.util.List;
 
 @RestController
@@ -23,7 +17,7 @@ public class VisitController {
 
     @GetMapping(value = "")
     public List<VisitModel> getVisits() {
-        return visitService.getUpcomingVisits();
+        return visitService.fetchUpcoming();
     }
 
     @PostMapping("/new")

--- a/src/main/java/com/realyoungk/sdi/dto/TelegramChatDto.java
+++ b/src/main/java/com/realyoungk/sdi/dto/TelegramChatDto.java
@@ -1,0 +1,10 @@
+package com.realyoungk.sdi.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TelegramChatDto(
+        @JsonProperty("id") Long id
+) {
+}

--- a/src/main/java/com/realyoungk/sdi/dto/TelegramMessageDto.java
+++ b/src/main/java/com/realyoungk/sdi/dto/TelegramMessageDto.java
@@ -1,0 +1,12 @@
+package com.realyoungk.sdi.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TelegramMessageDto(
+        @JsonProperty("message_id") Long messageId,
+        @JsonProperty("chat") TelegramChatDto chat,
+        @JsonProperty("text") String text
+) {
+}

--- a/src/main/java/com/realyoungk/sdi/dto/TelegramUpdateDto.java
+++ b/src/main/java/com/realyoungk/sdi/dto/TelegramUpdateDto.java
@@ -1,0 +1,11 @@
+package com.realyoungk.sdi.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TelegramUpdateDto(
+        @JsonProperty("update_id") Long updateId,
+        @JsonProperty("message") TelegramMessageDto message
+) {
+}

--- a/src/main/java/com/realyoungk/sdi/repository/TelegramRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/TelegramRepository.java
@@ -3,13 +3,16 @@ package com.realyoungk.sdi.repository;
 import com.realyoungk.sdi.config.TelegramProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Repository;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @Repository
@@ -21,18 +24,22 @@ public class TelegramRepository {
     public void sendMessage(String chatId, String message) {
         String url = telegramProperties.baseUrl() + telegramProperties.botToken() + "/sendMessage";
 
-        URI uri = UriComponentsBuilder.fromUriString(url)
-                .queryParam("chat_id", chatId)
-                .queryParam("text", message)
-                .build(true)
-                .toUri();
+        Map<String, String> body = new HashMap<>();
+        body.put("chat_id", chatId);
+        body.put("text", message);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
 
-        ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
-
-        if (response.getStatusCode().is2xxSuccessful()) {
-            log.info("Message sent successfully to chat_id: {}", chatId);
-        } else {
-            log.error("Failed to send message: {} - {}", response.getStatusCode(), response.getBody());
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(url, requestEntity, String.class);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                log.info("Message sent successfully to chat_id: {}", chatId);
+            } else {
+                log.error("Failed to send message: {} - {}", response.getStatusCode(), response.getBody());
+            }
+        } catch (RestClientException e) {
+            log.error("Exception occurred while sending message to Telegram API", e);
         }
     }
 }

--- a/src/main/java/com/realyoungk/sdi/service/NotificationService.java
+++ b/src/main/java/com/realyoungk/sdi/service/NotificationService.java
@@ -1,0 +1,5 @@
+package com.realyoungk.sdi.service;
+
+public interface NotificationService {
+    void send(String destination, String message);
+}

--- a/src/main/java/com/realyoungk/sdi/service/TelegramNotificationService.java
+++ b/src/main/java/com/realyoungk/sdi/service/TelegramNotificationService.java
@@ -1,0 +1,17 @@
+package com.realyoungk.sdi.service;
+
+import com.realyoungk.sdi.repository.TelegramRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service("telegramNotificationService")
+@RequiredArgsConstructor
+public class TelegramNotificationService implements NotificationService {
+
+    private final TelegramRepository telegramRepository;
+
+    @Override
+    public void send(String chatId, String message) {
+        telegramRepository.sendMessage(chatId, message);
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/service/VisitService.java
+++ b/src/main/java/com/realyoungk/sdi/service/VisitService.java
@@ -31,7 +31,7 @@ public class VisitService {
     private final GoogleSheetRepository googleSheetRepository;
     private final GoogleSheetsProperties googleSheetsProperties;
 
-    public String createUpcomingVisitsMessage() {
+    public String createMessage() {
         final LocalDateTime localDateTime = LocalDateTime.now();
         final Date startedAt = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
         final List<VisitModel> visitModels = fetchUpcoming();


### PR DESCRIPTION
텔레그램 봇과의 연동을 위한 기능을 추가하고, 이를 통해 방문 일정 알림을 발송하는 서비스를 구현했습니다.

**주요 변경 사항:**

- **텔레그램 콜백 컨트롤러 추가 (`CallbackController.java`)**
    - 텔레그램 서버로부터 업데이트(메시지 등)를 수신하는 `/api/v1/callbacks/telegram` 엔드포인트를 구현했습니다.
    - 수신된 메시지가 `/visits` 명령일 경우, `VisitService`를 통해 방문 일정 메시지를 생성하고 `NotificationService`를 통해 사용자에게 전송합니다.
    - 입력값 검증 및 로깅 기능을 포함합니다.

- **알림 서비스 인터페이스 및 구현체 추가**
    - **`NotificationService.java`**: 메시지 발송 기능을 추상화한 인터페이스입니다.
    - **`TelegramNotificationService.java`**: `NotificationService`의 텔레그램 구현체로, `TelegramRepository`를 사용하여 실제 메시지를 발송합니다.

- **텔레그램 DTO 추가**
    - `TelegramUpdateDto.java`, `TelegramMessageDto.java`, `TelegramChatDto.java`: 텔레그램 API 응답을 파싱하기 위한 데이터 전송 객체(DTO)를 정의했습니다. `@JsonIgnoreProperties(ignoreUnknown = true)` 어노테이션을 사용하여 불필요한 필드는 무시합니다.

- **텔레그램 저장소 로직 개선 (`TelegramRepository.java`)**
    - `sendMessage` 메서드에서 GET 요청 대신 POST 요청을 사용하도록 변경하여, 보다 안정적인 메시지 전송 방식을 채택했습니다.
    - 요청 본문에 `chat_id`와 `text`를 JSON 형태로 담아 전송합니다.
    - `RestClientException` 예외 처리를 추가하여 API 호출 실패 시 에러를 로깅합니다.

- **기존 코드 수정**
    - **`VisitController.java`**: `getUpcomingVisits()` 메서드 호출을 `fetchUpcoming()`으로 변경했습니다. (메서드명 변경은 이전 커밋에서 이루어진 것으로 보이나, 해당 파일에서의 호출 부분을 수정)
    - **`VisitService.java`**: `createUpcomingVisitsMessage()` 메서드명을 `createMessage()`로 변경하여 보다 일반적인 의미를 갖도록 했습니다.

이번 변경을 통해 사용자는 텔레그램 봇에게 `/visits` 명령을 보내 다가오는 방문 일정을 알림으로 받을 수 있게 되었습니다.