### PR TITLE
feat: 매일 아침 8시 방문 일정 알림 기능 추가

### DIFF
--- a/src/main/java/com/realyoungk/sdi/SdiApplication.java
+++ b/src/main/java/com/realyoungk/sdi/SdiApplication.java
@@ -3,9 +3,11 @@ package com.realyoungk.sdi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class SdiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/realyoungk/sdi/scheduler/VisitScheduler.java
+++ b/src/main/java/com/realyoungk/sdi/scheduler/VisitScheduler.java
@@ -1,0 +1,28 @@
+package com.realyoungk.sdi.scheduler;
+
+import com.realyoungk.sdi.config.TelegramProperties;
+import com.realyoungk.sdi.service.NotificationService;
+import com.realyoungk.sdi.service.VisitService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VisitScheduler {
+
+    private final VisitService visitService;
+    private final NotificationService notificationService;
+    private final TelegramProperties telegramProperties;
+
+    @Scheduled(cron = "0 0 8 * * *") // 매일 아침 8시 0분 0초에 실행
+    public void sendDailyVisitNotification() {
+        log.info("매일 아침 8시 탐방 일정 알림 배치를 시작합니다.");
+        final String visitsMessage = visitService.createMessage();
+        final String chatId = telegramProperties.testChatId();
+        notificationService.send(chatId, visitsMessage);
+        log.info("Chat ID '{}'로 탐방 일정 알림을 성공적으로 전송했습니다.", chatId);
+    }
+}


### PR DESCRIPTION
매일 아침 8시에 방문 일정을 조회하여 텔레그램으로 알림을 보내는 스케줄러 기능을 추가했습니다.

- `VisitScheduler` 클래스 생성:
    - `@Scheduled(cron = "0 0 8 * * *")` 어노테이션을 사용하여 매일 아침 8시에 `sendDailyVisitNotification` 메서드가 실행되도록 설정했습니다.
    - 해당 메서드는 `VisitService`를 통해 방문 일정 메시지를 생성하고, `NotificationService`를 통해 지정된 텔레그램 채팅방으로 메시지를 전송합니다.
    - 실행 시작과 성공적인 전송에 대한 로그를 기록합니다.
- `SdiApplication` 클래스 수정:
    - `@EnableScheduling` 어노테이션을 추가하여 스케줄링 기능을 활성화했습니다.