### PR TITLE
refactor: cron 표현식 주석 제거

### DIFF
--- a/src/main/java/com/realyoungk/sdi/scheduler/VisitScheduler.java
+++ b/src/main/java/com/realyoungk/sdi/scheduler/VisitScheduler.java
@@ -17,7 +17,7 @@ public class VisitScheduler {
     private final NotificationService notificationService;
     private final TelegramProperties telegramProperties;
 
-    @Scheduled(cron = "0 0 8 * * *") // 매일 아침 8시 0분 0초에 실행
+    @Scheduled(cron = "0 0 8 * * *")
     public void sendDailyVisitNotification() {
         log.info("매일 아침 8시 탐방 일정 알림 배치를 시작합니다.");
         final String visitsMessage = visitService.createMessage();


### PR DESCRIPTION
VisitScheduler의 `sendDailyVisitNotification` 메서드에서 `@Scheduled` 어노테이션의 cron 표현식 뒤에 있던 주석을 제거했습니다.

이는 Spring Framework의 `CronExpression` 클래스나 일반적인 cron 표현식([1], [2])에서 주석을 지원하지 않기 때문에, 불필요하거나 잠재적으로 문제를 일으킬 수 있는 부분을 정리한 것입니다.

[1] CronExpression (Spring Framework 6.2.9 API)
[2] Cron Expressions