### PR TITLE
refactor: 클래스 VisitDto의 이름을 VisitEntity로 변경하여 JPA 엔티티임을 더 명확하게 반영했습니다…

### DIFF
--- a/src/main/java/com/realyoungk/sdi/entity/VisitEntity.java
+++ b/src/main/java/com/realyoungk/sdi/entity/VisitEntity.java
@@ -1,4 +1,4 @@
-package com.realyoungk.sdi.dto;
+package com.realyoungk.sdi.entity;
 
 import com.realyoungk.sdi.model.VisitModel;
 import jakarta.persistence.Entity;
@@ -18,7 +18,7 @@ import java.util.UUID;
 @EqualsAndHashCode(of = "id")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class VisitDto {
+public class VisitEntity {
     @Id
     private String id;
     private Date createdAt;
@@ -38,7 +38,7 @@ public class VisitDto {
     private String remark;
 
     @Builder
-    private VisitDto(String id, Date createdAt, Date updatedAt, Date startedAt, Date finishedAt, String participantCount, String teamName, String organizer, String remark) {
+    private VisitEntity(String id, Date createdAt, Date updatedAt, Date startedAt, Date finishedAt, String participantCount, String teamName, String organizer, String remark) {
         this.id = id;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -50,8 +50,8 @@ public class VisitDto {
         this.remark = remark;
     }
 
-    public static VisitDto fromModel(VisitModel model) {
-        return VisitDto.builder()
+    public static VisitEntity fromModel(VisitModel model) {
+        return VisitEntity.builder()
                 .id(UUID.randomUUID().toString())
                 .createdAt(new Date())
                 .updatedAt(new Date())

--- a/src/main/java/com/realyoungk/sdi/repository/VisitJpaRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/VisitJpaRepository.java
@@ -1,7 +1,7 @@
 package com.realyoungk.sdi.repository;
 
-import com.realyoungk.sdi.dto.VisitDto;
+import com.realyoungk.sdi.entity.VisitEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VisitJpaRepository extends JpaRepository<VisitDto, String>, VisitRepository {
+public interface VisitJpaRepository extends JpaRepository<VisitEntity, String>, VisitRepository {
 }

--- a/src/main/java/com/realyoungk/sdi/repository/VisitRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/VisitRepository.java
@@ -1,7 +1,7 @@
 package com.realyoungk.sdi.repository;
 
 
-import com.realyoungk.sdi.dto.VisitDto;
+import com.realyoungk.sdi.entity.VisitEntity;
 import org.springframework.stereotype.Repository;
 
 import java.util.Date;
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Repository
 public interface VisitRepository {
-    List<VisitDto> findByStartedAtAfterOrderByStartedAtDesc(Date startedAt);
+    List<VisitEntity> findByStartedAtAfterOrderByStartedAtDesc(Date startedAt);
 
-    VisitDto save(VisitDto visitDto);
+    VisitEntity save(VisitEntity visitEntity);
 }

--- a/src/main/java/com/realyoungk/sdi/service/VisitService.java
+++ b/src/main/java/com/realyoungk/sdi/service/VisitService.java
@@ -1,7 +1,7 @@
 package com.realyoungk.sdi.service;
 
 import com.realyoungk.sdi.config.GoogleSheetsProperties;
-import com.realyoungk.sdi.dto.VisitDto;
+import com.realyoungk.sdi.entity.VisitEntity;
 import com.realyoungk.sdi.exception.VisitFetchException;
 import com.realyoungk.sdi.model.VisitModel;
 import com.realyoungk.sdi.repository.GoogleSheetRepository;
@@ -57,9 +57,9 @@ public class VisitService {
     }
 
     public VisitModel save(VisitModel visitModel) {
-        final VisitDto savedVisitDto = visitRepository.save(VisitDto.fromModel(visitModel));
+        final VisitEntity savedVisitEntity = visitRepository.save(VisitEntity.fromModel(visitModel));
 
-        return fromEntity(savedVisitDto);
+        return fromEntity(savedVisitEntity);
     }
 
     public List<VisitModel> fetchUpcoming() {
@@ -88,15 +88,15 @@ public class VisitService {
         }
     }
 
-    private VisitModel fromEntity(VisitDto visitDto) {
+    private VisitModel fromEntity(VisitEntity visitEntity) {
         return VisitModel.builder()
-                .id(visitDto.getId())
-                .startedAt(visitDto.getStartedAt())
-                .finishedAt(visitDto.getFinishedAt())
-                .participantCount(visitDto.getParticipantCount())
-                .teamName(visitDto.getTeamName())
-                .organizer(visitDto.getOrganizer())
-                .remark(visitDto.getRemark())
+                .id(visitEntity.getId())
+                .startedAt(visitEntity.getStartedAt())
+                .finishedAt(visitEntity.getFinishedAt())
+                .participantCount(visitEntity.getParticipantCount())
+                .teamName(visitEntity.getTeamName())
+                .organizer(visitEntity.getOrganizer())
+                .remark(visitEntity.getRemark())
                 .build();
     }
 


### PR DESCRIPTION
…. 이번 변경을 통해 코드베이스의 의미 전달력이 향상되었습니다.

영향을 받은 파일:
	•	src/main/java/com/realyoungk/sdi/entity/VisitEntity.java (VisitDto.java에서 이름 변경)
	•	src/main/java/com/realyoungk/sdi/service/VisitService.java
	•	src/main/java/com/realyoungk/sdi/repository/VisitJpaRepository.java
	•	src/main/java/com/realyoungk/sdi/repository/VisitRepository.java
기존 VisitDto로 되어 있던 모든 참조와 타입 선언도 VisitEntity로 변경되었습니다.