### PR TITLE
feat: User 엔티티 및 모델 추가

### DIFF
--- a/src/main/java/com/realyoungk/sdi/entity/UserEntity.java
+++ b/src/main/java/com/realyoungk/sdi/entity/UserEntity.java
@@ -1,0 +1,55 @@
+package com.realyoungk.sdi.entity;
+
+import com.realyoungk.sdi.model.CalendarType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "users")
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long internalId; // DB 내부에서만 사용할 숫자 ID (성능 최적화)
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private String id; // 외부에 노출될 고유 ID (UUID)
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 20)
+    private String phoneNumber;
+
+    private LocalDate birthday; // 생년월일 (YYYY-MM-DD)
+
+    @Enumerated(EnumType.STRING)
+    private CalendarType calendarType; // 양력/음력 구분
+
+    @Column(length = 100)
+    private String teamName; // 소속 스터디명
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.id == null) {
+            this.id = UUID.randomUUID().toString();
+        }
+    }
+
+    @Builder
+    public UserEntity(String name, String phoneNumber, LocalDate birthday, CalendarType calendarType, String teamName) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.birthday = birthday;
+        this.calendarType = calendarType;
+        this.teamName = teamName;
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/model/CalendarType.java
+++ b/src/main/java/com/realyoungk/sdi/model/CalendarType.java
@@ -1,0 +1,13 @@
+package com.realyoungk.sdi.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CalendarType {
+    SOLAR("양력"),
+    LUNAR("음력");
+
+    private final String description;
+}

--- a/src/main/java/com/realyoungk/sdi/model/UserModel.java
+++ b/src/main/java/com/realyoungk/sdi/model/UserModel.java
@@ -1,0 +1,25 @@
+package com.realyoungk.sdi.model;
+
+import com.realyoungk.sdi.entity.UserEntity;
+
+import java.time.LocalDate;
+
+public record UserModel(
+        String id, // 외부에 노출할 아이디
+        String name, // 이름
+        String phoneNumber, // 휴대폰번호
+        LocalDate birthday, // 생일
+        CalendarType calendarType, // 양력/음력 구분
+        String teamName // 소속 스터디명
+) {
+    public static UserModel from(UserEntity entity) {
+        return new UserModel(
+                entity.getId(),
+                entity.getName(),
+                entity.getPhoneNumber(),
+                entity.getBirthday(),
+                entity.getCalendarType(),
+                entity.getTeamName()
+        );
+    }
+}


### PR DESCRIPTION
- UserEntity: 사용자 정보를 저장하는 JPA 엔티티
  - `internalId`: DB 내부용 숫자 ID (PK, 자동 증가)
  - `id`: 외부 노출용 UUID (고유, 수정 불가)
  - `name`: 이름 (필수)
  - `phoneNumber`: 휴대폰 번호
  - `birthday`: 생년월일 (YYYY-MM-DD)
  - `calendarType`: 양력/음력 구분 (`CalendarType` enum)
  - `teamName`: 소속 스터디명
  - `@PrePersist`를 통해 엔티티 저장 전 `id`에 UUID 자동 할당
- CalendarType: 양력/음력을 나타내는 enum
  - `SOLAR("양력")`
  - `LUNAR("음력")`
- UserModel: User 엔티티의 데이터를 전달하는 record
  - `UserEntity`로부터 `UserModel`을 생성하는 `from` 정적 팩토리 메서드 제공