### PR TITLE
feat: 음력 생일 사용자 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,6 @@ java {
 	}
 }
 
-repositories {
-	mavenCentral()
-}
-
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
@@ -43,6 +39,8 @@ dependencies {
     // Telegram Bots Spring Boot Starter
     implementation 'org.telegram:telegrambots-springboot-webhook-starter:7.4.0'
 
+    // 한국 음력 변환 라이브러리
+    implementation "com.github.FrancescoJo:korean-lunar-calendar:1.0.2"
 }
 
 tasks.named('test') {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = 'sdi'
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/entity/UserEntity.java
+++ b/src/main/java/com/realyoungk/sdi/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package com.realyoungk.sdi.entity;
 
-import com.realyoungk.sdi.model.CalendarType;
+import com.realyoungk.sdi.model.CalendarType; // import 추가
+import com.realyoungk.sdi.model.LunarMonthType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,10 +19,10 @@ public class UserEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long internalId; // DB 내부에서만 사용할 숫자 ID (성능 최적화)
+    private Long id;
 
     @Column(nullable = false, unique = true, updatable = false)
-    private String id; // 외부에 노출될 고유 ID (UUID)
+    private String publicId;
 
     @Column(nullable = false, length = 50)
     private String name;
@@ -29,27 +30,33 @@ public class UserEntity {
     @Column(length = 20)
     private String phoneNumber;
 
-    private LocalDate birthday; // 생년월일 (YYYY-MM-DD)
+    private LocalDate birthday;
 
     @Enumerated(EnumType.STRING)
-    private CalendarType calendarType; // 양력/음력 구분
+    private CalendarType calendarType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LunarMonthType lunarMonthType = LunarMonthType.NORMAL;
+
 
     @Column(length = 100)
-    private String teamName; // 소속 스터디명
+    private String teamName;
 
     @PrePersist
     protected void onCreate() {
-        if (this.id == null) {
-            this.id = UUID.randomUUID().toString();
+        if (this.publicId == null) {
+            this.publicId = UUID.randomUUID().toString();
         }
     }
 
     @Builder
-    public UserEntity(String name, String phoneNumber, LocalDate birthday, CalendarType calendarType, String teamName) {
+    public UserEntity(String name, String phoneNumber, LocalDate birthday, CalendarType calendarType, LunarMonthType lunarMonthType, String teamName) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.birthday = birthday;
         this.calendarType = calendarType;
+        this.lunarMonthType = (calendarType == CalendarType.SOLAR) ? LunarMonthType.NORMAL : lunarMonthType;
         this.teamName = teamName;
     }
 }

--- a/src/main/java/com/realyoungk/sdi/model/LunarMonthType.java
+++ b/src/main/java/com/realyoungk/sdi/model/LunarMonthType.java
@@ -1,0 +1,13 @@
+package com.realyoungk.sdi.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LunarMonthType {
+    NORMAL("일반달"),
+    LEAP("윤달");
+
+    private final String description;
+}

--- a/src/main/java/com/realyoungk/sdi/model/UserModel.java
+++ b/src/main/java/com/realyoungk/sdi/model/UserModel.java
@@ -1,25 +1,71 @@
 package com.realyoungk.sdi.model;
 
+import com.github.fj.koreanlunarcalendar.KoreanLunarCalendarUtils;
+import com.github.fj.koreanlunarcalendar.KoreanLunarDate;
 import com.realyoungk.sdi.entity.UserEntity;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDate;
 
+@Slf4j
 public record UserModel(
-        String id, // 외부에 노출할 아이디
-        String name, // 이름
-        String phoneNumber, // 휴대폰번호
-        LocalDate birthday, // 생일
-        CalendarType calendarType, // 양력/음력 구분
-        String teamName // 소속 스터디명
+        String id,
+        String name,
+        String phoneNumber,
+        String teamName,
+        LocalDate birthday,
+        CalendarType calendarType,
+        LunarMonthType lunarMonthType
 ) {
     public static UserModel from(UserEntity entity) {
         return new UserModel(
-                entity.getId(),
+                entity.getPublicId(),
                 entity.getName(),
                 entity.getPhoneNumber(),
+                entity.getTeamName(),
                 entity.getBirthday(),
                 entity.getCalendarType(),
-                entity.getTeamName()
+                entity.getLunarMonthType()
         );
+    }
+
+    public LocalDate getSolarBirthdayThisYear(int year) {
+        if (this.birthday == null || this.calendarType == null) {
+            return null;
+        }
+
+        return switch (this.calendarType) {
+            case SOLAR -> this.birthday.withYear(year);
+            case LUNAR -> convertLunarToSolarWithApproximation(this.birthday, year);
+        };
+    }
+
+    private LocalDate convertLunarToSolarWithApproximation(LocalDate lunarDate, int targetYear) {
+        int month = lunarDate.getMonthValue();
+        int day = lunarDate.getDayOfMonth();
+        boolean isLeap = (this.lunarMonthType == LunarMonthType.LEAP);
+
+        try {
+            KoreanLunarDate result = KoreanLunarCalendarUtils.getSolarDateOf(
+                    targetYear, month, day, isLeap
+            );
+            return LocalDate.of(result.solYear, result.solMonth, result.solDay);
+        } catch (Exception e) {
+            if (day == 30) {
+                log.warn("음력 30일 변환 실패, 근사치(29일)로 재시도합니다. lunarDate={}, isLeap={}, targetYear={}", lunarDate, isLeap, targetYear);
+                try {
+                    KoreanLunarDate result = KoreanLunarCalendarUtils.getSolarDateOf(
+                            targetYear, month, 29, isLeap
+                    );
+                    return LocalDate.of(result.solYear, result.solMonth, result.solDay);
+                } catch (Exception e2) {
+                    log.error("음력 변환 최종 실패 (근사치 29일 시도 포함): lunarDate={}, isLeap={}, targetYear={}", lunarDate, isLeap, targetYear, e2);
+                    return null;
+                }
+            } else {
+                log.warn("음력 변환 실패: lunarDate={}, isLeap={}, targetYear={}", lunarDate, isLeap, targetYear, e);
+                return null;
+            }
+        }
     }
 }

--- a/src/main/java/com/realyoungk/sdi/repository/UserRepository.java
+++ b/src/main/java/com/realyoungk/sdi/repository/UserRepository.java
@@ -1,0 +1,29 @@
+package com.realyoungk.sdi.repository;
+
+import com.realyoungk.sdi.entity.UserEntity;
+import com.realyoungk.sdi.model.CalendarType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+    Optional<UserEntity> findByPublicId(String publicId);
+
+    Optional<UserEntity> findByPhoneNumber(String phoneNumber);
+
+    List<UserEntity> findByName(String name);
+
+    @Query("SELECT u FROM UserEntity u WHERE u.calendarType = com.realyoungk.sdi.model.CalendarType.SOLAR AND EXTRACT(MONTH FROM u.birthday) = :month AND EXTRACT(DAY FROM u.birthday) = :day")
+    List<UserEntity> findUsersWithSolarBirthday(@Param("month") int month, @Param("day") int day);
+
+    @Query("SELECT u FROM UserEntity u WHERE u.calendarType = com.realyoungk.sdi.model.CalendarType.SOLAR AND EXTRACT(MONTH FROM u.birthday) = :month")
+    List<UserEntity> findUsersWithSolarBirthdayInMonth(@Param("month") int month);
+
+    List<UserEntity> findByCalendarType(CalendarType calendarType);
+}

--- a/src/main/java/com/realyoungk/sdi/service/UserService.java
+++ b/src/main/java/com/realyoungk/sdi/service/UserService.java
@@ -1,0 +1,108 @@
+package com.realyoungk.sdi.service;
+
+import com.github.fj.koreanlunarcalendar.KoreanLunarCalendarUtils;
+import com.github.fj.koreanlunarcalendar.KoreanLunarDate;
+import com.realyoungk.sdi.entity.UserEntity;
+import com.realyoungk.sdi.model.CalendarType;
+import com.realyoungk.sdi.model.LunarMonthType;
+import com.realyoungk.sdi.model.UserModel;
+import com.realyoungk.sdi.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 특정 날짜가 생일인 모든 사용자(양력/음력 포함)를 조회합니다.
+     */
+    public List<UserModel> findUsersWithBirthdayOn(LocalDate date) {
+        List<UserEntity> solarBirthdayUsers = userRepository.findUsersWithSolarBirthday(
+                date.getMonthValue(),
+                date.getDayOfMonth()
+        );
+
+        List<UserEntity> lunarBirthdayUsers = findLunarBirthdayUsersOn(date);
+
+        return Stream.concat(solarBirthdayUsers.stream(), lunarBirthdayUsers.stream())
+                .distinct() // 중복 제거
+                .map(UserModel::from)
+                .toList();
+    }
+
+    /**
+     * 특정 날짜가 속한 달이 생일인 모든 사용자(양력/음력 포함)를 조회합니다.
+     */
+    public List<UserModel> findUsersWithBirthdayIn(LocalDate date) {
+        int targetMonth = date.getMonthValue();
+
+        List<UserEntity> solarBirthdayUsers = userRepository.findUsersWithSolarBirthdayInMonth(targetMonth);
+
+        List<UserEntity> lunarBirthdayUsers = findLunarBirthdayUsersIn(targetMonth);
+
+        return Stream.concat(solarBirthdayUsers.stream(), lunarBirthdayUsers.stream())
+                .distinct()
+                .map(UserModel::from)
+                .toList();
+    }
+
+
+    private List<UserEntity> findLunarBirthdayUsersOn(LocalDate targetSolarDate) {
+        List<UserEntity> allLunarUsers = userRepository.findByCalendarType(CalendarType.LUNAR);
+
+        return allLunarUsers.stream()
+                .filter(user -> {
+                    LocalDate solarBirthdayThisYear = convertLunarToSolar(
+                            user.getBirthday(),
+                            targetSolarDate.getYear(),
+                            user.getLunarMonthType() == LunarMonthType.LEAP
+                    );
+                    return targetSolarDate.equals(solarBirthdayThisYear);
+                })
+                .toList();
+    }
+
+    private List<UserEntity> findLunarBirthdayUsersIn(int targetMonth) {
+        List<UserEntity> allLunarUsers = userRepository.findByCalendarType(CalendarType.LUNAR);
+        int currentYear = LocalDate.now().getYear();
+
+        return allLunarUsers.stream()
+                .filter(user -> {
+                    LocalDate solarBirthdayThisYear = convertLunarToSolar(
+                            user.getBirthday(),
+                            currentYear,
+                            user.getLunarMonthType() == LunarMonthType.LEAP
+                    );
+                    return solarBirthdayThisYear != null && solarBirthdayThisYear.getMonthValue() == targetMonth;
+                })
+                .toList();
+    }
+
+    /**
+     * 사용자의 음력 생일을 특정 년도의 양력 생일로 변환합니다.
+     * 알려주신 static 메서드 호출 방식으로 수정했습니다.
+     */
+    private LocalDate convertLunarToSolar(LocalDate lunarDate, int targetYear, boolean isLeapMonth) {
+        try {
+            KoreanLunarDate result = KoreanLunarCalendarUtils.getSolarDateOf(
+                    targetYear,
+                    lunarDate.getMonthValue(),
+                    lunarDate.getDayOfMonth(),
+                    isLeapMonth
+            );
+            return LocalDate.of(result.solYear, result.solMonth, result.solDay);
+        } catch (Exception e) {
+            log.warn("음력 변환 실패: lunarDate={}, targetYear={}", lunarDate, targetYear, e);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- `LunarMonthType` Enum (일반달/윤달)을 추가하고 `UserEntity`에 반영했습니다.
- `UserRepository`에 음력 생일 관련 쿼리 메서드를 추가했습니다.
- `UserService`에 다음 기능을 구현했습니다:
    - 특정 날짜가 생일인 사용자 조회 (양/음력 모두)
    - 특정 월이 생일인 사용자 조회 (양/음력 모두)
    - 음력 생일을 양력으로 변환하는 로직 (외부 라이브러리 `korean-lunar-calendar` 사용)
- `UserModel`에 `lunarMonthType` 필드를 추가하고, 해당 연도 양력 생일 계산 로직을 개선했습니다.
  - 음력 30일 변환 실패 시 29일로 근사치 변환을 시도합니다.
- `build.gradle`에 `korean-lunar-calendar` 라이브러리 의존성을 추가하고, `settings.gradle`에 JitPack 저장소를 추가했습니다.
- `UserEntity`의 ID 필드명을 `id`에서 `internalId`로, `publicId`를 `id`로 변경하여 외부 노출 ID와 내부 DB ID를 명확히 구분했습니다. (이후 커밋에서 `internalId`는 `id`로, `id`는 `publicId`로 다시 정정됨)