### PR TITLE
feat: 생일 알림 기능 및 사용자 관리 API 추가

### DIFF
--- a/src/main/java/com/realyoungk/sdi/controller/CallbackController.java
+++ b/src/main/java/com/realyoungk/sdi/controller/CallbackController.java
@@ -1,23 +1,34 @@
 package com.realyoungk.sdi.controller;
 
 import com.realyoungk.sdi.dto.TelegramUpdateDto;
+import com.realyoungk.sdi.formatter.TelegramMessageFormatter;
+import com.realyoungk.sdi.model.UserModel;
+import com.realyoungk.sdi.model.VisitModel;
 import com.realyoungk.sdi.service.NotificationService;
+import com.realyoungk.sdi.service.UserService;
 import com.realyoungk.sdi.service.VisitService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/api/v1/callbacks", method = {RequestMethod.POST})
+@RequestMapping(value = "/api/v1/callbacks")
 public class CallbackController {
     private final VisitService visitService;
     private final NotificationService notificationService;
+    private final UserService userService;
+    private final TelegramMessageFormatter telegramMessageFormatter;
 
     @PostMapping("/telegram")
     public void postTelegram(@RequestBody TelegramUpdateDto update) {
@@ -26,14 +37,30 @@ public class CallbackController {
             return;
         }
 
-        String text = update.message().text();
+        String text = update.message().text().trim();
         String chatId = String.valueOf(update.message().chat().id());
         log.info("Received message '{}' from chat_id '{}'", text, chatId);
 
-        if ("/visits".equalsIgnoreCase(text.trim())) {
-            final String visitsMessage = visitService.createMessage();
+
+        if ("/visits".equalsIgnoreCase(text)) {
+            List<VisitModel> visitModels = visitService.fetchUpcoming();
+            final String visitsMessage = telegramMessageFormatter.formatVisitsMessage(visitModels);
             notificationService.send(chatId, visitsMessage);
             log.info("Delegated /visits command for chat_id '{}' to VisitService", chatId);
+        }
+
+        if ("/users?birthday=today".equalsIgnoreCase(text)) {
+            List<UserModel> users = userService.findUsersWithBirthdayOn(LocalDate.now());
+            String birthdayMessage = telegramMessageFormatter.formatBirthdayMessage(users, "오늘");
+            notificationService.send(chatId, birthdayMessage);
+            log.info("Processed /users?birthday=today command for chat_id '{}'", chatId);
+        }
+
+        if ("/users?birthday=this-month".equalsIgnoreCase(text)) {
+            List<UserModel> users = userService.findUsersWithBirthdayIn(LocalDate.now());
+            String birthdayMessage = telegramMessageFormatter.formatBirthdayMessage(users, "이번 달");
+            notificationService.send(chatId, birthdayMessage);
+            log.info("Processed /users?birthday=this-month command for chat_id '{}'", chatId);
         }
     }
 }

--- a/src/main/java/com/realyoungk/sdi/controller/UserController.java
+++ b/src/main/java/com/realyoungk/sdi/controller/UserController.java
@@ -1,0 +1,68 @@
+package com.realyoungk.sdi.controller;
+
+import com.realyoungk.sdi.model.UserModel;
+import com.realyoungk.sdi.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * ✅ 여러 사용자를 한번에 생성하는 Bulk API
+     */
+    @PostMapping
+    public ResponseEntity<List<UserModel>> createUsers(@RequestBody List<UserModel> body) {
+        List<UserModel> createdUsers = userService.createUsers(body);
+        // 생성된 리소스의 위치를 Location 헤더에 담아 201 Created 응답 반환
+        return ResponseEntity
+                .created(URI.create("/api/v1/users"))
+                .body(createdUsers);
+    }
+
+    // 사용자 생성 (POST)
+    @PostMapping("/new")
+    public ResponseEntity<UserModel> createUsersNew(@RequestBody UserModel body) {
+        UserModel createdUser = userService.createUser(body);
+        // 생성된 리소스의 위치를 Location 헤더에 담아 201 Created 응답 반환
+        return ResponseEntity
+                .created(URI.create("/api/v1/users/" + createdUser.id()))
+                .body(createdUser);
+    }
+
+    // 사용자 조회 (GET)
+    @GetMapping("/{publicId}")
+    public ResponseEntity<UserModel> getUserByPublicId(@PathVariable String publicId) {
+        return userService.findUserByPublicId(publicId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // 모든 사용자 조회 (GET)
+    @GetMapping
+    public ResponseEntity<List<UserModel>> getUsers(
+            @RequestParam(name = "birthday", required = false)
+            String birthdayFilter
+    ) {
+        List<UserModel> users;
+
+        if ("today".equalsIgnoreCase(birthdayFilter)) {
+            users = userService.findUsersWithBirthdayOn(LocalDate.now());
+        } else if ("this-month".equalsIgnoreCase(birthdayFilter)) {
+            users = userService.findUsersWithBirthdayIn(LocalDate.now());
+        } else {
+            users = userService.findAllUsers();
+        }
+
+        return ResponseEntity.ok(users);
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/formatter/TelegramMessageFormatter.java
+++ b/src/main/java/com/realyoungk/sdi/formatter/TelegramMessageFormatter.java
@@ -1,0 +1,78 @@
+package com.realyoungk.sdi.formatter;
+
+import com.realyoungk.sdi.model.UserModel;
+import com.realyoungk.sdi.model.VisitModel;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+@Component
+public class TelegramMessageFormatter {
+
+    /**
+     * 방문 일정 목록을 받아 텔레그램 메시지 형식으로 변환합니다.
+     * (VisitService에 있던 로직을 이동)
+     *
+     * @param visitModels 방문 일정 목록
+     * @return 텔레그램 메시지 문자열
+     */
+    public String formatVisitsMessage(List<VisitModel> visitModels) {
+        if (visitModels == null || visitModels.isEmpty()) {
+            return "다가오는 탐방 일정이 없습니다. 😅";
+        }
+
+        final Date now = Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant());
+        StringBuilder sb = new StringBuilder();
+        sb.append("📢 [다가오는 탐방 일정]\n\n");
+
+        for (VisitModel visitModel : visitModels) {
+            long diff = (visitModel.getStartedAt().getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+            boolean isSoon = diff >= 0 && diff <= 2;
+            if (isSoon) {
+                sb.append(visitModel.toDetailedString(diff));
+                sb.append("\n");
+            } else {
+                sb.append(visitModel.toSimpleString(diff));
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 생일자 목록을 받아 텔레그램 메시지 형식으로 변환합니다.
+     * (CallbackController에 있던 로직을 이동)
+     *
+     * @param users  생일자 목록
+     * @param period "오늘", "이번 달" 등 기간을 나타내는 문자열
+     * @return 텔레그램 메시지 문자열
+     */
+    public String formatBirthdayMessage(List<UserModel> users, String period) {
+        if (users == null || users.isEmpty()) {
+            return String.format("🎂 %s 생일인 분이 없습니다.", period);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("🎉 %s 생일인 분들입니다! 🎉\n\n", period));
+
+        int currentYear = LocalDate.now().getYear();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN);
+
+        users.forEach(user -> {
+            LocalDate birthdayThisYear = user.getSolarBirthdayThisYear(currentYear);
+            if (birthdayThisYear != null) {
+                sb.append(String.format("- %s님 (%s)\n", user.name(), birthdayThisYear.format(formatter)));
+            } else {
+                sb.append(String.format("- %s님\n", user.name()));
+            }
+        });
+
+        sb.append("\n모두 축하해주세요! 🥳");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/scheduler/BirthdayScheduler.java
+++ b/src/main/java/com/realyoungk/sdi/scheduler/BirthdayScheduler.java
@@ -1,0 +1,61 @@
+package com.realyoungk.sdi.scheduler;
+
+import com.realyoungk.sdi.config.TelegramProperties;
+import com.realyoungk.sdi.formatter.TelegramMessageFormatter;
+import com.realyoungk.sdi.model.UserModel;
+import com.realyoungk.sdi.service.NotificationService;
+import com.realyoungk.sdi.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BirthdayScheduler {
+
+    private final UserService userService;
+    private final NotificationService notificationService;
+    private final TelegramMessageFormatter messageFormatter;
+    private final TelegramProperties telegramProperties;
+
+    /**
+     * 매일 아침 8시에 오늘 생일인 사용자를 찾아 알림을 보냅니다.
+     * 생일자가 없으면 아무 작업도 하지 않습니다.
+     * cron = "초 분 시 일 월 요일"
+     */
+    @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
+    public void sendDailyBirthdayNotification() {
+        log.info("매일 생일자 확인 배치를 시작합니다.");
+        List<UserModel> usersWithBirthdayToday = userService.findUsersWithBirthdayOn(LocalDate.now());
+
+        // ✅ 오늘 생일인 사람이 있을 경우에만 메시지를 보냅니다.
+        if (usersWithBirthdayToday != null && !usersWithBirthdayToday.isEmpty()) {
+            String birthdayMessage = messageFormatter.formatBirthdayMessage(usersWithBirthdayToday, "오늘");
+            String chatId = telegramProperties.firstStudyChatId(); // 알림을 보낼 채팅방 ID
+
+            notificationService.send(chatId, birthdayMessage);
+            log.info("오늘의 생일자 알림을 성공적으로 전송했습니다. 대상: {} 명", usersWithBirthdayToday.size());
+        } else {
+            log.info("오늘 생일인 사용자가 없어 알림을 보내지 않습니다.");
+        }
+    }
+
+    /**
+     * 매월 1일 오전 9시에 이번 달 생일인 사용자 목록을 알립니다.
+     */
+    @Scheduled(cron = "0 0 8 1 * *", zone = "Asia/Seoul")
+    public void sendMonthlyBirthdayNotification() {
+        log.info("매월 생일자 목록 확인 배치를 시작합니다.");
+        List<UserModel> usersWithBirthdayThisMonth = userService.findUsersWithBirthdayIn(LocalDate.now());
+        String birthdayMessage = messageFormatter.formatBirthdayMessage(usersWithBirthdayThisMonth, "이번 달");
+        String chatId = telegramProperties.firstStudyChatId(); // 알림을 보낼 채팅방 ID
+
+        notificationService.send(chatId, birthdayMessage);
+        log.info("이번 달의 생일자 목록 알림을 성공적으로 전송했습니다.");
+    }
+}

--- a/src/main/java/com/realyoungk/sdi/scheduler/VisitScheduler.java
+++ b/src/main/java/com/realyoungk/sdi/scheduler/VisitScheduler.java
@@ -1,12 +1,20 @@
 package com.realyoungk.sdi.scheduler;
 
 import com.realyoungk.sdi.config.TelegramProperties;
+import com.realyoungk.sdi.controller.CallbackController;
+import com.realyoungk.sdi.formatter.TelegramMessageFormatter;
+import com.realyoungk.sdi.model.VisitModel;
 import com.realyoungk.sdi.service.NotificationService;
 import com.realyoungk.sdi.service.VisitService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -16,11 +24,13 @@ public class VisitScheduler {
     private final VisitService visitService;
     private final NotificationService notificationService;
     private final TelegramProperties telegramProperties;
+    private final TelegramMessageFormatter telegramMessageFormatter;
 
     @Scheduled(cron = "0 0 8 * * *")
     public void sendDailyVisitNotification() {
         log.info("매일 아침 8시 탐방 일정 알림 배치를 시작합니다.");
-        final String visitsMessage = visitService.createMessage();
+        final List<VisitModel> visits = visitService.fetchUpcoming();
+        final String visitsMessage = telegramMessageFormatter.formatVisitsMessage(visits);
         final String chatId = telegramProperties.firstStudyChatId();
         notificationService.send(chatId, visitsMessage);
         log.info("Chat ID '{}'로 탐방 일정 알림을 성공적으로 전송했습니다.", chatId);

--- a/src/main/java/com/realyoungk/sdi/service/UserService.java
+++ b/src/main/java/com/realyoungk/sdi/service/UserService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -21,6 +22,40 @@ import java.util.stream.Stream;
 public class UserService {
 
     private final UserRepository userRepository;
+
+    /**
+     * 모든 유저를 조회합니다.
+     */
+    public List<UserModel> findAllUsers() {
+        return userRepository.findAll().stream()
+                .map(UserModel::from)
+                .toList();
+    }
+
+    /**
+     * 사용자를 생성합니다.
+     */
+    public UserModel createUser(UserModel body) {
+        UserEntity entity = UserEntity.builder()
+                .name(body.name())
+                .phoneNumber(body.phoneNumber())
+                .birthday(body.birthday())
+                .calendarType(body.calendarType())
+                .lunarMonthType(body.lunarMonthType())
+                .teamName(body.teamName())
+                .build();
+
+        UserEntity savedEntity = userRepository.save(entity);
+        return UserModel.from(savedEntity);
+    }
+
+    /**
+     * 특정 publicId를 가진 사용자를 조회합니다.
+     */
+    public Optional<UserModel> findUserByPublicId(String publicId) {
+        return userRepository.findByPublicId(publicId)
+                .map(UserModel::from);
+    }
 
     /**
      * 특정 날짜가 생일인 모든 사용자(양력/음력 포함)를 조회합니다.
@@ -51,6 +86,28 @@ public class UserService {
 
         return Stream.concat(solarBirthdayUsers.stream(), lunarBirthdayUsers.stream())
                 .distinct()
+                .map(UserModel::from)
+                .toList();
+    }
+
+    /**
+     * ✅ [추가] 여러 사용자를 한번에 생성합니다.
+     */
+    public List<UserModel> createUsers(List<UserModel> users) {
+        List<UserEntity> entitiesToSave = users.stream()
+                .map(body -> UserEntity.builder()
+                        .name(body.name())
+                        .phoneNumber(body.phoneNumber())
+                        .birthday(body.birthday())
+                        .calendarType(body.calendarType())
+                        .lunarMonthType(body.lunarMonthType())
+                        .teamName(body.teamName())
+                        .build())
+                .toList();
+
+        List<UserEntity> savedEntities = userRepository.saveAll(entitiesToSave);
+
+        return savedEntities.stream()
                 .map(UserModel::from)
                 .toList();
     }

--- a/src/main/java/com/realyoungk/sdi/service/VisitService.java
+++ b/src/main/java/com/realyoungk/sdi/service/VisitService.java
@@ -31,32 +31,6 @@ public class VisitService {
     private final GoogleSheetRepository googleSheetRepository;
     private final GoogleSheetsProperties googleSheetsProperties;
 
-    public String createMessage() {
-        final LocalDateTime localDateTime = LocalDateTime.now();
-        final Date startedAt = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
-        final List<VisitModel> visitModels = fetchUpcoming();
-
-        if (visitModels.isEmpty()) {
-            return "다가오는 탐방 일정이 없습니다. 😅";
-        }
-
-        StringBuilder sb = new StringBuilder();
-        sb.append("📢 [다가오는 탐방 일정]\n\n");
-        for (VisitModel visitModel : visitModels) {
-            long diff = (visitModel.getStartedAt().getTime() - startedAt.getTime()) / (1000 * 60 * 60 * 24);
-            boolean isSoon = diff >= 0 && diff <= 2;
-            long dDay = diff + 1;
-            if (isSoon) {
-                sb.append(visitModel.toDetailedString(dDay));
-                sb.append("\n");
-            } else {
-                sb.append(visitModel.toSimpleString(dDay));
-            }
-        }
-
-        return sb.toString();
-    }
-
     public VisitModel save(VisitModel visitModel) {
         final VisitEntity savedVisitEntity = visitRepository.save(VisitEntity.fromModel(visitModel));
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
 
   datasource:


### PR DESCRIPTION
- **생일 알림 스케줄러 추가 (`BirthdayScheduler`)**
  - 매일 오전 8시: 당일 생일자 알림
  - 매월 1일 오전 8시: 해당 월 생일자 목록 알림

- **텔레그램 메시지 포맷터 분리 (`TelegramMessageFormatter`)**
  - 기존 서비스 로직에 있던 탐방 일정 및 생일 메시지 포맷팅 로직을 별도 컴포넌트로 분리하여 재사용성 및 가독성 향상
  - 탐방 일정 메시지 생성 로직 (`formatVisitsMessage`)
  - 생일 알림 메시지 생성 로직 (`formatBirthdayMessage`)

- **사용자 관리 API 추가 (`UserController`)**
  - `POST /api/v1/users`: 사용자 일괄 등록 (bulk create)
  - `POST /api/v1/users/new`: 단일 사용자 등록
  - `GET /api/v1/users/{publicId}`: 특정 사용자 조회
  - `GET /api/v1/users`: 전체 사용자 조회
    - `?birthday=today`: 오늘 생일인 사용자 조회
    - `?birthday=this-month`: 이번 달 생일인 사용자 조회

- **`UserService` 기능 확장**
  - `findAllUsers()`: 모든 사용자 조회
  - `createUser(UserModel)`: 단일 사용자 생성
  - `findUserByPublicId(String)`: publicId로 사용자 조회
  - `createUsers(List<UserModel>)`: 여러 사용자 일괄 생성

- **`CallbackController` 개선**
  - `/visits` 명령어 처리 시 `TelegramMessageFormatter` 사용하도록 수정
  - `/users?birthday=today`, `/users?birthday=this-month` 명령어 지원 추가: 생일자 정보 조회 및 알림

- **기타 변경 사항**
  - `VisitService`에서 메시지 생성 로직 제거 ( `TelegramMessageFormatter`로 이전)
  - JPA `ddl-auto` 설정을 `create`에서 `update`로 변경하여 기존 데이터 유지