### PR TITLE
refactor: DateUtils를 범용적인 날짜 유틸리티로 개선

### DIFF
--- a/src/main/kotlin/com/realyoungk/sdi/utils/DateUtils.kt
+++ b/src/main/kotlin/com/realyoungk/sdi/utils/DateUtils.kt
@@ -4,15 +4,50 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 object DateUtils {
-    private val formatter = DateTimeFormatter.ofPattern("MM월 dd일")
+    private val koreanMonthDayFormatter = DateTimeFormatter.ofPattern("MM월 dd일")
     
-    fun formatBirthday(date: LocalDate?): String {
-        return date?.format(formatter) ?: "정보 없음"
+    /**
+     * 날짜를 한국어 월일 형식으로 포맷팅합니다.
+     * @param date 포맷팅할 날짜
+     * @param defaultMessage 날짜가 null일 때 반환할 기본 메시지
+     * @return 포맷팅된 문자열 (예: "12월 25일") 또는 기본 메시지
+     */
+    fun formatToKoreanMonthDay(date: LocalDate?, defaultMessage: String = "정보 없음"): String {
+        return date?.format(koreanMonthDayFormatter) ?: defaultMessage
     }
     
-    fun isValidBirthday(date: LocalDate?): Boolean {
+    /**
+     * 날짜가 지정된 범위 내에 있는지 확인합니다.
+     * @param date 확인할 날짜
+     * @param maxYearsAgo 과거 최대 연수 (기본: 150년)
+     * @param allowToday 오늘 날짜 허용 여부 (기본: false)
+     * @return 유효한 날짜인지 여부
+     */
+    fun isDateInValidRange(
+        date: LocalDate?, 
+        maxYearsAgo: Long = 150, 
+        allowToday: Boolean = false
+    ): Boolean {
+        if (date == null) return false
+        
+        val now = LocalDate.now()
+        val maxPastDate = now.minusYears(maxYearsAgo)
+        
+        val isNotTooOld = date.isAfter(maxPastDate)
+        val isNotFuture = if (allowToday) !date.isAfter(now) else date.isBefore(now)
+        
+        return isNotTooOld && isNotFuture
+    }
+    
+    /**
+     * 날짜가 과거인지 확인합니다.
+     * @param date 확인할 날짜
+     * @param includeToday 오늘 포함 여부 (기본: false)
+     * @return 과거 날짜인지 여부
+     */
+    fun isPastDate(date: LocalDate?, includeToday: Boolean = false): Boolean {
         if (date == null) return false
         val now = LocalDate.now()
-        return date.isBefore(now) && date.isAfter(now.minusYears(150))
+        return if (includeToday) !date.isAfter(now) else date.isBefore(now)
     }
 }

--- a/src/test/kotlin/com/realyoungk/sdi/enums/CalendarTypeTest.kt
+++ b/src/test/kotlin/com/realyoungk/sdi/enums/CalendarTypeTest.kt
@@ -1,0 +1,43 @@
+package com.realyoungk.sdi.enums
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class CalendarTypeTest {
+
+    @Test
+    fun `양력_타입은_올바른_한글_설명을_가져야한다`() {
+        // When
+        val result = CalendarType.SOLAR.description
+        
+        // Then
+        assertEquals("양력", result)
+    }
+
+    @Test
+    fun `음력_타입은_올바른_한글_설명을_가져야한다`() {
+        // When
+        val result = CalendarType.LUNAR.description
+        
+        // Then
+        assertEquals("음력", result)
+    }
+
+    @Test
+    fun `달력_타입은_정확히_2개여야한다`() {
+        // When
+        val values = CalendarType.values()
+        
+        // Then
+        assertEquals(2, values.size)
+        assertTrue(values.contains(CalendarType.SOLAR))
+        assertTrue(values.contains(CalendarType.LUNAR))
+    }
+
+    @Test
+    fun `문자열로부터_달력_타입을_올바르게_변환할_수_있어야한다`() {
+        // When & Then
+        assertEquals(CalendarType.SOLAR, CalendarType.valueOf("SOLAR"))
+        assertEquals(CalendarType.LUNAR, CalendarType.valueOf("LUNAR"))
+    }
+}

--- a/src/test/kotlin/com/realyoungk/sdi/enums/LunarMonthTypeTest.kt
+++ b/src/test/kotlin/com/realyoungk/sdi/enums/LunarMonthTypeTest.kt
@@ -1,0 +1,55 @@
+package com.realyoungk.sdi.enums
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class LunarMonthTypeTest {
+
+    @Test
+    fun `일반달_타입은_올바른_한글_설명을_가져야한다`() {
+        // When
+        val result = LunarMonthType.NORMAL.description
+        
+        // Then
+        assertEquals("일반달", result)
+    }
+
+    @Test
+    fun `윤달_타입은_올바른_한글_설명을_가져야한다`() {
+        // When
+        val result = LunarMonthType.LEAP.description
+        
+        // Then
+        assertEquals("윤달", result)
+    }
+
+    @Test
+    fun `음력_달_타입은_정확히_2개여야한다`() {
+        // When
+        val values = LunarMonthType.values()
+        
+        // Then
+        assertEquals(2, values.size)
+        assertTrue(values.contains(LunarMonthType.NORMAL))
+        assertTrue(values.contains(LunarMonthType.LEAP))
+    }
+
+    @Test
+    fun `문자열로부터_음력_달_타입을_올바르게_변환할_수_있어야한다`() {
+        // When & Then
+        assertEquals(LunarMonthType.NORMAL, LunarMonthType.valueOf("NORMAL"))
+        assertEquals(LunarMonthType.LEAP, LunarMonthType.valueOf("LEAP"))
+    }
+
+    @Test
+    fun `윤달은_음력_달력에서_특별한_의미를_가진_달을_나타낸다`() {
+        // Given
+        val leapMonth = LunarMonthType.LEAP
+        val normalMonth = LunarMonthType.NORMAL
+        
+        // Then
+        assertNotEquals(leapMonth, normalMonth)
+        assertEquals("윤달", leapMonth.description)
+        assertEquals("일반달", normalMonth.description)
+    }
+}

--- a/src/test/kotlin/com/realyoungk/sdi/utils/DateUtilsTest.kt
+++ b/src/test/kotlin/com/realyoungk/sdi/utils/DateUtilsTest.kt
@@ -1,0 +1,174 @@
+package com.realyoungk.sdi.utils
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import java.time.LocalDate
+
+class DateUtilsTest {
+
+    // formatToKoreanMonthDay 테스트
+    @Test
+    fun `날짜를_한국어_월일_형식으로_포맷팅해야한다`() {
+        // Given
+        val date = LocalDate.of(2023, 12, 25)
+        
+        // When
+        val result = DateUtils.formatToKoreanMonthDay(date)
+        
+        // Then
+        assertEquals("12월 25일", result)
+    }
+
+    @Test
+    fun `null_날짜는_기본_메시지를_반환해야한다`() {
+        // When
+        val result = DateUtils.formatToKoreanMonthDay(null)
+        
+        // Then
+        assertEquals("정보 없음", result)
+    }
+
+    @Test
+    fun `null_날짜에_대해_커스텀_메시지를_반환할_수_있어야한다`() {
+        // When
+        val result = DateUtils.formatToKoreanMonthDay(null, "날짜 미정")
+        
+        // Then
+        assertEquals("날짜 미정", result)
+    }
+
+    @Test
+    fun `한자리수_월과_일을_앞에_0을_붙여_포맷팅해야한다`() {
+        // Given
+        val date = LocalDate.of(2023, 1, 5)
+        
+        // When
+        val result = DateUtils.formatToKoreanMonthDay(date)
+        
+        // Then
+        assertEquals("01월 05일", result)
+    }
+
+    // isDateInValidRange 테스트
+    @Test
+    fun `null_날짜는_유효하지않다고_판단해야한다`() {
+        // When
+        val result = DateUtils.isDateInValidRange(null)
+        
+        // Then
+        assertFalse(result)
+    }
+
+    @Test
+    fun `일반적인_과거_날짜는_유효하다고_판단해야한다`() {
+        // Given
+        val pastDate = LocalDate.now().minusYears(25)
+        
+        // When
+        val result = DateUtils.isDateInValidRange(pastDate)
+        
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `미래_날짜는_기본적으로_유효하지않다고_판단해야한다`() {
+        // Given
+        val futureDate = LocalDate.now().plusDays(1)
+        
+        // When
+        val result = DateUtils.isDateInValidRange(futureDate)
+        
+        // Then
+        assertFalse(result)
+    }
+
+    @Test
+    fun `기본_150년보다_오래된_날짜는_유효하지않다고_판단해야한다`() {
+        // Given
+        val tooOldDate = LocalDate.now().minusYears(151)
+        
+        // When
+        val result = DateUtils.isDateInValidRange(tooOldDate)
+        
+        // Then
+        assertFalse(result)
+    }
+
+    @Test
+    fun `커스텀_연수_제한을_설정할_수_있어야한다`() {
+        // Given
+        val date = LocalDate.now().minusYears(200)
+        
+        // When
+        val resultWith150 = DateUtils.isDateInValidRange(date, maxYearsAgo = 150)
+        val resultWith250 = DateUtils.isDateInValidRange(date, maxYearsAgo = 250)
+        
+        // Then
+        assertFalse(resultWith150)
+        assertTrue(resultWith250)
+    }
+
+    @Test
+    fun `오늘_날짜_허용_옵션을_사용할_수_있어야한다`() {
+        // Given
+        val today = LocalDate.now()
+        
+        // When
+        val resultNotAllowed = DateUtils.isDateInValidRange(today, allowToday = false)
+        val resultAllowed = DateUtils.isDateInValidRange(today, allowToday = true)
+        
+        // Then
+        assertFalse(resultNotAllowed)
+        assertTrue(resultAllowed)
+    }
+
+    // isPastDate 테스트
+    @Test
+    fun `과거_날짜를_올바르게_판단해야한다`() {
+        // Given
+        val pastDate = LocalDate.now().minusDays(1)
+        
+        // When
+        val result = DateUtils.isPastDate(pastDate)
+        
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `오늘_날짜는_기본적으로_과거가_아니라고_판단해야한다`() {
+        // Given
+        val today = LocalDate.now()
+        
+        // When
+        val result = DateUtils.isPastDate(today)
+        
+        // Then
+        assertFalse(result)
+    }
+
+    @Test
+    fun `오늘_포함_옵션으로_오늘을_과거로_판단할_수_있어야한다`() {
+        // Given
+        val today = LocalDate.now()
+        
+        // When
+        val result = DateUtils.isPastDate(today, includeToday = true)
+        
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `미래_날짜는_과거가_아니라고_판단해야한다`() {
+        // Given
+        val futureDate = LocalDate.now().plusDays(1)
+        
+        // When
+        val result = DateUtils.isPastDate(futureDate)
+        
+        // Then
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
- 생일 특화 함수를 범용적인 날짜 처리 함수로 변경
- formatBirthday() → formatToKoreanMonthDay()로 이름 변경 및 커스텀 메시지 지원
- isValidBirthday() → isDateInValidRange()로 분리하여 유연한 옵션 제공
- isPastDate() 함수 추가로 과거 날짜 판단 기능 분리
- 매개변수를 통한 연수 제한, 오늘 날짜 허용 등 커스터마이징 가능
- 14개 테스트로 확장하여 새로운 기능들 검증

🤖 Generated with [Claude Code](https://claude.ai/code)